### PR TITLE
Add GHC 8.6.5 and GHC 8.10.2 to CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,53 @@
+name: Haskell CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ["8.6.5", "8.10.2"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Select build directory
+      run: echo "CABAL_BUILDDIR=dist" >> $GITHUB_ENV
+
+    - uses: actions/setup-haskell@v1
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: '3.2.0.0'
+
+    - name: Cabal update
+      run: cabal update
+
+    - name: Cabal Configure
+      run: cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
+
+    - uses: actions/cache@v2
+      name: Cache cabal store
+      with:
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist
+        key: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-${{ github.sha }}
+        restore-keys: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-
+
+    - name: Install dependencies
+      run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
+
+    - name: Build
+      run: cabal build all --builddir="$CABAL_BUILDDIR"
+
+    - name: Run tests
+      run: cabal test all --builddir="$CABAL_BUILDDIR"


### PR DESCRIPTION
This enables Github Actions CI.  The CI configuration is simple and should require minimal maintenance.

Having CI will help with maintenance of the library, inclusive of ensuring the library works with new versions of GHC whilst ensuring it continues to work with older versions of GHC we still use.

Evidence that the CI works is provided separately here because the permissions on this repository requires me to do this from a fork which does not run the Github Actions workflow.

https://github.com/newhoggy/goblins/actions/runs/346378931
